### PR TITLE
Add real-model integration tests for HuggingFace pipeline

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,14 @@ from PIL import Image
 from modules.ai_detector import AIImageDetector
 
 
+def pytest_addoption(parser):
+    parser.addoption("--real-model", action="store_true", default=False, help="Run tests against the real HuggingFace model")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "real_model: requires --real-model flag and HuggingFace model download")
+
+
 @pytest.fixture
 def sample_image():
     """Create a simple RGB test image."""

--- a/tests/test_e2e_api.py
+++ b/tests/test_e2e_api.py
@@ -1,0 +1,118 @@
+"""End-to-end tests: real HuggingFace pipeline through the FastAPI layer.
+
+Run with:
+    pytest tests/test_e2e_api.py -v --real-model
+
+The real detector is loaded once per session (scope=module) and injected into
+the API globals — no mocks, full request path exercised.
+"""
+
+import base64
+import importlib
+import io
+import tempfile
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from api.rate_limiter import TokenBucketRateLimiter
+from modules.ai_detector import AIImageDetector
+from modules.image_cache import ImageCache
+from modules.json_logger import JSONLogger
+
+VALID_VERDICTS = {"Likely AI", "Likely Real", "Uncertain"}
+
+
+def _b64_image(color: tuple = (128, 128, 128), size: tuple = (224, 224)) -> str:
+    img = Image.new("RGB", size, color=color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+@pytest.fixture(scope="module")
+def real_api_client(request):
+    if not request.config.getoption("--real-model"):
+        pytest.skip("Pass --real-model to run end-to-end API tests")
+
+    from api.config import get_settings
+    get_settings.cache_clear()
+
+    real_detector = AIImageDetector()
+
+    import api.server
+
+    with patch("api.server.AIImageDetector", return_value=real_detector):
+        importlib.reload(api.server)
+        api.server.detector = real_detector
+        api.server.cache = ImageCache(max_size=10, ttl=300)
+        api.server.json_logger = JSONLogger(log_dir=tempfile.mkdtemp())
+        api.server.rate_limiter = TokenBucketRateLimiter(requests_per_window=30, window_seconds=60)
+
+        yield TestClient(api.server.app, raise_server_exceptions=True)
+
+
+class TestE2EAnalyze:
+    def test_analyze_returns_200(self, real_api_client):
+        resp = real_api_client.post("/analyze", json={
+            "image_base64": _b64_image(),
+            "source_url": "https://example.com",
+        })
+        assert resp.status_code == 200
+
+    def test_analyze_response_shape(self, real_api_client):
+        data = real_api_client.post("/analyze", json={
+            "image_base64": _b64_image(),
+            "source_url": "https://example.com",
+        }).json()
+        assert set(data.keys()) >= {
+            "is_ai", "confidence", "verdict",
+            "fake_probability", "real_probability",
+            "image_hash", "processing_time_ms", "cached",
+        }
+
+    def test_analyze_verdict_is_valid(self, real_api_client):
+        data = real_api_client.post("/analyze", json={
+            "image_base64": _b64_image(),
+            "source_url": "https://example.com",
+        }).json()
+        assert data["verdict"] in VALID_VERDICTS
+
+    def test_probabilities_sum_to_one(self, real_api_client):
+        data = real_api_client.post("/analyze", json={
+            "image_base64": _b64_image(),
+            "source_url": "https://example.com",
+        }).json()
+        assert abs(data["fake_probability"] + data["real_probability"] - 1.0) < 0.01
+
+    def test_confidence_matches_verdict(self, real_api_client):
+        data = real_api_client.post("/analyze", json={
+            "image_base64": _b64_image(),
+            "source_url": "https://example.com",
+        }).json()
+        if data["verdict"] == "Likely AI":
+            assert data["confidence"] == pytest.approx(data["fake_probability"])
+            assert data["confidence"] > 0.6
+        elif data["verdict"] == "Likely Real":
+            assert data["confidence"] == pytest.approx(data["real_probability"])
+            assert data["confidence"] > 0.6
+        else:
+            assert data["verdict"] == "Uncertain"
+            assert data["confidence"] <= 0.6
+
+    def test_second_request_is_cached(self, real_api_client):
+        b64 = _b64_image(color=(200, 100, 50))
+        # Send twice — second must always be a cache hit regardless of first
+        real_api_client.post("/analyze", json={"image_base64": b64, "source_url": "https://example.com"})
+        r2 = real_api_client.post("/analyze", json={"image_base64": b64, "source_url": "https://example.com"})
+        assert r2.status_code == 200
+        assert r2.json()["cached"] is True
+
+    def test_invalid_base64_returns_400(self, real_api_client):
+        resp = real_api_client.post("/analyze", json={
+            "image_base64": "not-valid-base64!!!",
+            "source_url": "https://example.com",
+        })
+        assert resp.status_code == 400

--- a/tests/test_real_pipeline.py
+++ b/tests/test_real_pipeline.py
@@ -12,7 +12,6 @@ from PIL import Image, ImageDraw
 from modules.ai_detector import AIImageDetector
 
 
-
 @pytest.fixture(scope="module")
 def real_detector(request):
     if not request.config.getoption("--real-model"):

--- a/tests/test_real_pipeline.py
+++ b/tests/test_real_pipeline.py
@@ -1,0 +1,83 @@
+"""Integration tests that run inference against the real HuggingFace model.
+
+Run with:
+    pytest tests/test_real_pipeline.py -v --real-model
+
+Skipped by default to avoid the ~400 MB model download in CI.
+"""
+
+import pytest
+from PIL import Image, ImageDraw
+
+from modules.ai_detector import AIImageDetector
+
+
+
+@pytest.fixture(scope="module")
+def real_detector(request):
+    if not request.config.getoption("--real-model"):
+        pytest.skip("Pass --real-model to run real pipeline tests")
+    return AIImageDetector()
+
+
+def _solid_image(color: tuple, size: tuple = (256, 256)) -> Image.Image:
+    return Image.new("RGB", size, color=color)
+
+
+def _gradient_image(size: tuple = (256, 256)) -> Image.Image:
+    img = Image.new("RGB", size)
+    draw = ImageDraw.Draw(img)
+    for x in range(size[0]):
+        shade = int(x / size[0] * 255)
+        draw.line([(x, 0), (x, size[1])], fill=(shade, shade, shade))
+    return img
+
+
+class TestRealPipeline:
+    def test_returns_expected_keys(self, real_detector):
+        img = _solid_image((128, 128, 128))
+        result = real_detector.analyze_image(img)
+        assert set(result.keys()) == {
+            "is_ai", "confidence", "verdict", "full_analysis",
+            "fake_probability", "real_probability", "processing_time_ms",
+        }
+
+    def test_probabilities_sum_to_one(self, real_detector):
+        img = _solid_image((200, 100, 50))
+        result = real_detector.analyze_image(img)
+        total = result["fake_probability"] + result["real_probability"]
+        assert abs(total - 1.0) < 0.01
+
+    def test_confidence_matches_verdict(self, real_detector):
+        img = _gradient_image()
+        result = real_detector.analyze_image(img)
+        if result["verdict"] == "Likely AI":
+            assert result["confidence"] == pytest.approx(result["fake_probability"])
+            assert result["confidence"] > 0.6
+        elif result["verdict"] == "Likely Real":
+            assert result["confidence"] == pytest.approx(result["real_probability"])
+            assert result["confidence"] > 0.6
+        else:
+            assert result["verdict"] == "Uncertain"
+            assert result["confidence"] <= 0.6
+
+    def test_processing_time_positive(self, real_detector):
+        img = _solid_image((0, 0, 0))
+        result = real_detector.analyze_image(img)
+        assert result["processing_time_ms"] > 0
+
+    def test_rgba_input_handled(self, real_detector):
+        img = Image.new("RGBA", (256, 256), color=(128, 128, 128, 255))
+        result = real_detector.analyze_image(img)
+        assert "verdict" in result
+
+    def test_large_image_resized_and_analyzed(self, real_detector):
+        img = _solid_image((100, 150, 200), size=(2048, 2048))
+        result = real_detector.analyze_image(img)
+        assert "verdict" in result
+
+    def test_model_info(self, real_detector):
+        info = real_detector.get_model_info()
+        assert info["name"] == "umm-maybe/AI-image-detector"
+        assert info["accuracy"] == "94.2%"
+        assert info["device"] in ("cpu", "cuda")


### PR DESCRIPTION
## Summary

- Adds `--real-model` pytest flag (skipped by default, safe for CI) that gates tests against the live ViT model
- `tests/test_real_pipeline.py` — 7 tests that exercise the `AIImageDetector` directly: output shape, probability coherence, verdict/confidence alignment, RGBA handling, large image resizing
- `tests/test_e2e_api.py` — 7 end-to-end tests that send real images through the full API → detector → response path with no mocks; covers caching, error handling, and response shape
- `tests/conftest.py` — adds `pytest_addoption` hook to register the `--real-model` flag

## Running

```bash
# Skipped by default (CI-safe)
pytest tests/ -v

# Run real pipeline tests (requires ~400MB model cached in ~/.cache/huggingface/)
pytest tests/ -v --real-model
```

## Test plan
- [x] `pytest tests/ -v` — 41 passed, 14 skipped
- [x] `pytest tests/ -v --real-model` — 55 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)