### PR TITLE
Add pywin32 to requirements.txt for Windows pystray support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ python-dotenv>=1.0.0
 mss>=9.0.0
 pystray>=0.19.0
 plyer>=2.1.0
+pywin32>=306; sys_platform == "win32"
 imagehash>=4.3.0
 torch>=2.0.0
 torchvision>=0.15.0


### PR DESCRIPTION
## Summary

- `pywin32>=306` was present in the venv but missing from `requirements.txt`, causing `pystray` (and therefore `screen_monitor_clip.py`) to fail on a fresh Windows install
- Added with a `sys_platform == "win32"` marker so it only installs on Windows

## Test plan
- [x] `pip install -r requirements.txt` on Windows resolves `pywin32`
- [x] No change on Linux/macOS (platform marker excludes it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)