### PR TITLE
Add HEALTHCHECK to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ RUN mkdir -p logs
 
 EXPOSE 8000
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+
 CMD ["python", "-m", "uvicorn", "api.server:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary

Adds a `HEALTHCHECK` directive so Docker/compose knows when the container is actually ready, not just started.

- Polls `GET /health` every 30s using stdlib `urllib.request` (no extra deps)
- `--start-period=60s` gives the model time to download (~400MB on first run) and warm up before health checks start counting failures
- `--timeout=10s`, `--retries=3` before marking unhealthy

## Before
`docker-compose up` reported the container healthy immediately after the process started, before the ViT model had finished loading.

## After
Container stays in `starting` state until `/health` responds successfully.

## Test plan
- [x] `docker-compose up` — verified container transitions through `starting` → `healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)