### PR TITLE
Add /dashboard tests and remove stale pywin32 tech debt note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,4 +73,3 @@ All settings via environment variables (or `.env` file), defined in `api/config.
 ## Known Tech Debt
 - Desktop monitor file still named `screen_monitor_clip.py` (legacy from CLIP migration)
 - Extension content script does direct fetch instead of routing through service worker
-- `pystray` on Windows requires `pywin32`; already present in `.venv` but not in `requirements.txt`

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -106,6 +106,23 @@ class TestStatsEndpoint:
         assert "cache_hit_rate" in data
 
 
+class TestDashboardEndpoint:
+    def test_dashboard_returns_200(self, mock_env_no_auth, monkeypatch):
+        client = _create_app(monkeypatch)
+        resp = client.get("/dashboard")
+        assert resp.status_code == 200
+
+    def test_dashboard_returns_html(self, mock_env_no_auth, monkeypatch):
+        client = _create_app(monkeypatch)
+        resp = client.get("/dashboard")
+        assert "text/html" in resp.headers["content-type"]
+
+    def test_dashboard_no_auth_required(self, mock_env_with_auth, monkeypatch):
+        client = _create_app(monkeypatch)
+        resp = client.get("/dashboard")
+        assert resp.status_code == 200
+
+
 class TestAnalyzeEndpoint:
     def test_analyze_valid_image(self, mock_env_no_auth, monkeypatch):
         client = _create_app(monkeypatch)


### PR DESCRIPTION
## Summary

Two small housekeeping items:

**`/dashboard` tests** — last untested endpoint, adds 3 tests to `test_api.py`:
- Returns 200
- Content-type is `text/html`
- No auth required (public endpoint)

**Stale tech debt note** — removes the `pywin32` entry from `CLAUDE.md`; `pywin32>=306` was added to `requirements.txt` in PR #14 so the note is no longer accurate.

## Test plan
- [x] `pytest tests/test_api.py -v` — 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)